### PR TITLE
Update build pipelines

### DIFF
--- a/jenkins/agent/Jenkinsfile
+++ b/jenkins/agent/Jenkinsfile
@@ -25,12 +25,11 @@ node {
     }
   }
 
-  stage("Deploy ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
+  // The image is used by more than one deployment configuration, just tag it ...
+  stage("Deploy ${config.APP_NAME} to ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
     script {
-      deploy("${config.APP_NAME}",
-             "${config.SUFFIX}",
-             "${config.NAME_SPACE}",
-             "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
+      tagImage("${config.APP_NAME}",
+               "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
     }
   }
 }

--- a/jenkins/api/Jenkinsfile
+++ b/jenkins/api/Jenkinsfile
@@ -25,12 +25,11 @@ node {
     }
   }
 
-  stage("Deploy ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
+  // The image is used by more than one deployment configuration, just tag it ...
+  stage("Deploy ${config.APP_NAME} to ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
     script {
-      deploy("${config.APP_NAME}",
-             "${config.SUFFIX}",
-             "${config.NAME_SPACE}",
-             "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
+      tagImage("${config.APP_NAME}",
+               "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
     }
   }
 }

--- a/jenkins/db/Jenkinsfile
+++ b/jenkins/db/Jenkinsfile
@@ -25,12 +25,11 @@ node {
     }
   }
 
-  stage("Deploy ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
+  // The image is used by more than one deployment configuration, just tag it ...
+  stage("Deploy ${config.APP_NAME} to ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
     script {
-      deploy("${config.APP_NAME}",
-             "${config.SUFFIX}",
-             "${config.NAME_SPACE}",
-             "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
+      tagImage("${config.APP_NAME}",
+               "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
     }
   }
 }

--- a/jenkins/issuer-web/Jenkinsfile
+++ b/jenkins/issuer-web/Jenkinsfile
@@ -39,12 +39,11 @@ node {
     }
   }
 
-  stage("Deploy ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
+  // The image is used by more than one deployment configuration, just tag it ...
+  stage("Deploy ${config.APP_NAME} to ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
     script {
-      deploy("${config.APP_NAME}",
-             "${config.SUFFIX}",
-             "${config.NAME_SPACE}",
-             "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
+      tagImage("${config.APP_NAME}",
+               "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
     }
   }
 }

--- a/jenkins/wallet/Jenkinsfile
+++ b/jenkins/wallet/Jenkinsfile
@@ -25,12 +25,11 @@ node {
     }
   }
 
-  stage("Deploy ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
+  // The image is used by more than one deployment configuration, just tag it ...
+  stage("Deploy ${config.APP_NAME} to ${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}") {
     script {
-      deploy("${config.APP_NAME}",
-             "${config.SUFFIX}",
-             "${config.NAME_SPACE}",
-             "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
+      tagImage("${config.APP_NAME}",
+               "${config.DEPLOYMENT_ENVIRONMENT_TAGS[0]}")
     }
   }
 }

--- a/vars/tagImage.groovy
+++ b/vars/tagImage.groovy
@@ -1,0 +1,14 @@
+void call(String imageName, String tag) {
+  openshift.withCluster() {
+    openshift.withProject() {
+
+      echo "Tagging ${imageName} for deployment to ${tag} ..."
+
+      // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
+      // Tag the images for deployment based on the image's hash
+      def IMAGE_HASH = getImageTagHash(openshift, "${imageName}")
+      echo "IMAGE_HASH: ${IMAGE_HASH}"
+      openshift.tag("${imageName}@${IMAGE_HASH}", "${imageName}:${tag}")
+    }
+  }
+}


### PR DESCRIPTION
- Multiple instances of the same services will be deployed into any given environment.
- Simply tag the images and allow the deployment configurations to do the roll out rather than monitoring each.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>