### PR TITLE
Rename openvp issuer, add custom unauthorized file

### DIFF
--- a/openshift/templates/issuer-web/config/esr1/unauthorized.html
+++ b/openshift/templates/issuer-web/config/esr1/unauthorized.html
@@ -1,0 +1,13 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+    border: 1px solid #f5f5f5;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <p class="paragraph">This is a custom unauthorized content block.</p>
+</div> -->

--- a/openshift/templates/issuer-web/config/esr2/unauthorized.html
+++ b/openshift/templates/issuer-web/config/esr2/unauthorized.html
@@ -1,0 +1,13 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+    border: 1px solid #f5f5f5;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <p class="paragraph">This is a custom unauthorized content block.</p>
+</div> -->

--- a/openshift/templates/issuer-web/config/healthbc/unauthorized.html
+++ b/openshift/templates/issuer-web/config/healthbc/unauthorized.html
@@ -1,0 +1,13 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+    border: 1px solid #f5f5f5;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <p class="paragraph">This is a custom unauthorized content block.</p>
+</div> -->

--- a/openshift/templates/issuer-web/config/medlab/unauthorized.html
+++ b/openshift/templates/issuer-web/config/medlab/unauthorized.html
@@ -1,0 +1,13 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+    border: 1px solid #f5f5f5;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <p class="paragraph">This is a custom unauthorized content block.</p>
+</div> -->

--- a/openshift/templates/issuer-web/config/openvp/dev/config.json
+++ b/openshift/templates/issuer-web/config/openvp/dev/config.json
@@ -1,7 +1,7 @@
 {
   "env": "development",
   "issuer": {
-    "name": "\"Open\" Verified Person Issuer"
+    "name": "Unverified Person Issuer"
   },
   "inviteRequired": false,
   "authentication": {

--- a/openshift/templates/issuer-web/config/openvp/prod/config.json
+++ b/openshift/templates/issuer-web/config/openvp/prod/config.json
@@ -1,7 +1,7 @@
 {
   "env": "production",
   "issuer": {
-    "name": "\"Open\" Verified Person Issuer"
+    "name": "Unverified Person Issuer"
   },
   "inviteRequired": false,
   "authentication": {

--- a/openshift/templates/issuer-web/config/openvp/test/config.json
+++ b/openshift/templates/issuer-web/config/openvp/test/config.json
@@ -1,7 +1,7 @@
 {
   "env": "test",
   "issuer": {
-    "name": "\"Open\" Verified Person Issuer"
+    "name": "Unverified Person Issuer"
   },
   "inviteRequired": false,
   "authentication": {

--- a/openshift/templates/issuer-web/config/openvp/unauthorized.html
+++ b/openshift/templates/issuer-web/config/openvp/unauthorized.html
@@ -1,0 +1,13 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+    border: 1px solid #f5f5f5;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <p class="paragraph">This is a custom unauthorized content block.</p>
+</div> -->

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr1.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr1.param
@@ -19,6 +19,7 @@ APP_CONFIG_FILE_NAME=config.json
 APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
+APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=0.0.0.0
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr1.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr1.prod.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr1.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr1.test.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr2.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr2.param
@@ -19,6 +19,7 @@ APP_CONFIG_FILE_NAME=config.json
 APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
+APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=0.0.0.0
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr2.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr2.prod.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr2.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr2.test.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.healthbc.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.healthbc.param
@@ -19,6 +19,7 @@ APP_CONFIG_FILE_NAME=config.json
 APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
+APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=0.0.0.0
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.healthbc.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.healthbc.prod.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.healthbc.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.healthbc.test.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.json
+++ b/openshift/templates/issuer-web/issuer-web-deploy.json
@@ -124,6 +124,18 @@
                 }
               },
               {
+                "name": "${NAME}${SUFFIX}-app-unauthorized-volume",
+                "configMap": {
+                  "name": "${APP_CONFIG_MAP_NAME}${SUFFIX}",
+                  "items": [
+                    {
+                      "key": "${APP_UNAUTHORIZED_FILE_NAME}",
+                      "path": "${APP_UNAUTHORIZED_FILE_NAME}"
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "${NAME}${SUFFIX}-app-vuetify-volume",
                 "configMap": {
                   "name": "${APP_CONFIG_MAP_NAME}${SUFFIX}",
@@ -214,6 +226,11 @@
                     "name": "${NAME}${SUFFIX}-app-terms-volume",
                     "mountPath": "${APP_ARTIFACT_MOUNT_PATH}${APP_TERMS_FILE_NAME}",
                     "subPath": "${APP_TERMS_FILE_NAME}"
+                  },
+                  {
+                    "name": "${NAME}${SUFFIX}-app-unauthorized-volume",
+                    "mountPath": "${APP_ARTIFACT_MOUNT_PATH}${APP_UNAUTHORIZED_FILE_NAME}",
+                    "subPath": "${APP_UNAUTHORIZED_FILE_NAME}"
                   }
                 ],
                 "livenessProbe": {
@@ -489,6 +506,13 @@
       "description": "The name of the application terms file.",
       "required": true,
       "value": "terms-and-conditions.html"
+    },
+    {
+      "name": "APP_UNAUTHORIZED_FILE_NAME",
+      "displayName": "Application Unauthorized File Name",
+      "description": "The name of the application unauthorized file.",
+      "required": true,
+      "value": "unauthorized.html"
     },
     {
       "name": "WEB_HOST_NAME",

--- a/openshift/templates/issuer-web/issuer-web-deploy.medlab.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.medlab.param
@@ -19,6 +19,7 @@ APP_CONFIG_FILE_NAME=config.json
 APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
+APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=0.0.0.0
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.medlab.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.medlab.prod.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.medlab.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.medlab.test.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp.param
@@ -19,6 +19,7 @@ APP_CONFIG_FILE_NAME=config.json
 APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
+APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=0.0.0.0
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp.prod.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp.test.param
@@ -19,6 +19,7 @@
 # APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
+# APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=0.0.0.0
 # WEB_HOST_PORT=8080


### PR DESCRIPTION
The label of the openvp issuer has been changed to `Unverified Person`.

A custom unauthorized file has been added to support specifying additional deployment-specific content for the unauthorized view.

The change will require a redeploy of all `issuer-web` apps in order for the new configmap to be mounted. The changes to the codebase are in [this pull request](https://github.com/bcgov/identity-kit-poc/pull/177): no visible change will be displayed in the issuers since the default empty unauthorized file will be used.

The apps can be redeployed with the new configmap mount before the new image is available.