### PR TITLE
Update openvp issuer form

### DIFF
--- a/openshift/templates/issuer-web/config/openvp/claim-config.json
+++ b/openshift/templates/issuer-web/config/openvp/claim-config.json
@@ -65,6 +65,27 @@
       "defaultValue": "Canada",
       "isRequired": true,
       "requiredErrorText": "Required Field"
+    },
+    {
+      "type": "text",
+      "name": "issued",
+      "title": "Issued:",
+      "readOnly": true,
+      "isRequired": true
+    },
+    {
+      "type": "text",
+      "name": "placeholder",
+      "defaultValue": "placeholder",
+      "readOnly": true,
+      "visibleIf": "{issued} empty"
+    }
+  ],
+  "triggers": [
+    {
+      "type": "runexpression",
+      "expression": "{placeholder} notempty",
+      "runExpression": "setCurrentISODate('issued')"
     }
   ]
 }

--- a/openshift/templates/issuer-web/config/openvp/custom-scripts.js
+++ b/openshift/templates/issuer-web/config/openvp/custom-scripts.js
@@ -13,29 +13,7 @@ function setCurrentISODate(params) {
   survey.setValue(dateField, date.toISOString());
 }
 
-function setPHN(params) {
-  if (params.length < 1) {
-    throw new Error("setExpiryDate is missing one or more required parameters");
-  }
-  var phnField = params[0];
-  var survey = this.survey;
-
-  // Credit to: https://www.w3resource.com/javascript-exercises/javascript-math-exercise-23.php
-  var create_UUID = function () {
-    var dt = new Date().getTime();
-    var uuid = "xxxx xxx xxx".replace(
-      /[xy]/g,
-      function (c) {
-        var r = Math.floor(Math.random() * Math.floor(9))
-        return r;
-      }
-    );
-    return uuid;
-  };
-  survey.setValue(phnField, create_UUID());
-}
-
 /* An array containing custom functions that will be automatically registered with
- * SurveyJS so that they can be used in triggers.
- */
-surveyFunctions = [setCurrentISODate, setPHN];
+* SurveyJS so that they can be used in triggers.
+*/
+surveyFunctions = [setCurrentISODate];


### PR DESCRIPTION
Added `issued` claim to match schema - aca-py 0.5.2+ throws an error (as it should) when trying to issue a credential without providing all the fields defined in the schema