### PR TITLE
Update api deployment configurations for new version of issuer-kit

### DIFF
--- a/openshift/templates/api/api-deploy.json
+++ b/openshift/templates/api/api-deploy.json
@@ -371,6 +371,36 @@
           ]
         ]
       }
+    },
+    {
+      "kind": "NetworkSecurityPolicy",
+      "apiVersion": "secops.pathfinder.gov.bc.ca/v1alpha1",
+      "metadata": {
+        "name": "${NAME}${SUFFIX}-to-external-network",
+        "labels": {
+          "name": "${NAME}${SUFFIX}-to-external-network",
+          "app": "${APP_NAME}${SUFFIX}",
+          "app-group": "${APP_GROUP}",
+          "role": "${ROLE}",
+          "env": "${TAG_NAME}"
+        }
+      },
+      "spec": {
+        "description": "Allow the controller to access the internet.\n",
+        "source": [
+          [
+            "role=${ROLE}",
+            "app=${APP_NAME}${SUFFIX}",
+            "env=${TAG_NAME}",
+            "$namespace=${NAMESPACE_NAME}-${TAG_NAME}"
+          ]
+        ],
+        "destination": [
+          [
+            "ext:network=any"
+          ]
+        ]
+      }
     }
   ],
   "parameters": [

--- a/openshift/templates/api/config/esr1/dev/default.json
+++ b/openshift/templates/api/config/esr1/dev/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "Essential Services - Organization",
+    "offerComment": "Credential offer from Essential Services - Organization",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-dev.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/esr1/prod/default.json
+++ b/openshift/templates/api/config/esr1/prod/default.json
@@ -33,9 +33,13 @@
     "url": "PUBLIC_SITE_URL"
   },
   "issuer": {
-    "name": "MedLab",
-    "offerComment": "Credential offer from MedLab",
+    "name": "Essential Services - Organization",
+    "offerComment": "Credential offer from Essential Services - Organization",
     "validityDays": -1,
     "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
   }
 }

--- a/openshift/templates/api/config/esr1/schemas.json
+++ b/openshift/templates/api/config/esr1/schemas.json
@@ -9,6 +9,7 @@
     ],
     "schema_name": "service_provider",
     "schema_version": "0.1.0",
-    "default": true
+    "default": true,
+    "public": false
   }
 ]

--- a/openshift/templates/api/config/esr1/test/default.json
+++ b/openshift/templates/api/config/esr1/test/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "Essential Services - Organization",
+    "offerComment": "Credential offer from Essential Services - Organization",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-test.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/esr2/dev/default.json
+++ b/openshift/templates/api/config/esr2/dev/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "Essential Services - Access",
+    "offerComment": "Credential offer from Essential Services - Access",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-dev.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/esr2/prod/default.json
+++ b/openshift/templates/api/config/esr2/prod/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "Essential Services - Access",
+    "offerComment": "Credential offer from Essential Services - Access",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/esr2/schemas.json
+++ b/openshift/templates/api/config/esr2/schemas.json
@@ -13,6 +13,7 @@
     ],
     "schema_name": "authorized_access",
     "schema_version": "0.1.0",
-    "default": true
+    "default": true,
+    "public": false
   }
 ]

--- a/openshift/templates/api/config/esr2/test/default.json
+++ b/openshift/templates/api/config/esr2/test/default.json
@@ -37,5 +37,9 @@
     "offerComment": "Credential offer from Essential Services - Access",
     "validityDays": -1,
     "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-test.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
   }
 }

--- a/openshift/templates/api/config/healthbc/dev/default.json
+++ b/openshift/templates/api/config/healthbc/dev/default.json
@@ -33,9 +33,13 @@
     "url": "PUBLIC_SITE_URL"
   },
   "issuer": {
-    "name": "Essential Services - Organization",
-    "offerComment": "Credential offer from Essential Services - Organization",
+    "name": "HealthBC",
+    "offerComment": "Credential offer from HealthBC",
     "validityDays": -1,
     "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-dev.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
   }
 }

--- a/openshift/templates/api/config/healthbc/prod/default.json
+++ b/openshift/templates/api/config/healthbc/prod/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "HealthBC",
+    "offerComment": "Credential offer from HealthBC",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/healthbc/schemas.json
+++ b/openshift/templates/api/config/healthbc/schemas.json
@@ -6,6 +6,7 @@
     ],
     "schema_name": "vp_phn",
     "schema_version": "0.1.0",
-    "default": true
+    "default": true,
+    "public": false
   }
 ]

--- a/openshift/templates/api/config/healthbc/test/default.json
+++ b/openshift/templates/api/config/healthbc/test/default.json
@@ -33,9 +33,13 @@
     "url": "PUBLIC_SITE_URL"
   },
   "issuer": {
-    "name": "Unverified Person Issuer",
-    "offerComment": "Credential offer from Unverified Person Issuer",
+    "name": "HealthBC",
+    "offerComment": "Credential offer from HealthBC",
     "validityDays": -1,
     "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-test.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
   }
 }

--- a/openshift/templates/api/config/medlab/dev/default.json
+++ b/openshift/templates/api/config/medlab/dev/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "MedLab",
+    "offerComment": "Credential offer from MedLab",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-dev.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/medlab/prod/default.json
+++ b/openshift/templates/api/config/medlab/prod/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "MedLab",
+    "offerComment": "Credential offer from MedLab",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/medlab/schemas.json
+++ b/openshift/templates/api/config/medlab/schemas.json
@@ -12,6 +12,7 @@
     ],
     "schema_name": "c19_status",
     "schema_version": "0.1.0",
-    "default": true
+    "default": true,
+    "public": false
   }
 ]

--- a/openshift/templates/api/config/medlab/test/default.json
+++ b/openshift/templates/api/config/medlab/test/default.json
@@ -33,9 +33,13 @@
     "url": "PUBLIC_SITE_URL"
   },
   "issuer": {
-    "name": "HealthBC",
-    "offerComment": "Credential offer from HealthBC",
+    "name": "MedLab",
+    "offerComment": "Credential offer from MedLab",
     "validityDays": -1,
     "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-test.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
   }
 }

--- a/openshift/templates/api/config/openvp/dev/default.json
+++ b/openshift/templates/api/config/openvp/dev/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "Unverified Person Issuer",
+    "offerComment": "Credential offer from Unverified Person Issuer",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-dev.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/openvp/prod/default.json
+++ b/openshift/templates/api/config/openvp/prod/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "Unverified Person Issuer",
+    "offerComment": "Credential offer from Unverified Person Issuer",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}

--- a/openshift/templates/api/config/openvp/schemas.json
+++ b/openshift/templates/api/config/openvp/schemas.json
@@ -13,6 +13,7 @@
     ],
     "schema_name": "unverified_person",
     "schema_version": "0.1.0",
-    "default": true
+    "default": true,
+    "public": true
   }
 ]

--- a/openshift/templates/api/config/openvp/test/default.json
+++ b/openshift/templates/api/config/openvp/test/default.json
@@ -1,0 +1,45 @@
+{
+  "host": "localhost",
+  "port": "PORT",
+  "public": "../public/",
+  "paginate": {
+    "default": 10,
+    "max": 50
+  },
+  "mongodb": {
+    "host": "DB_SERVICE",
+    "db": "DB_NAME",
+    "port": "DB_PORT",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD"
+  },
+  "agent": {
+    "adminUrl": "AGENT_ADMIN_URL",
+    "adminApiKey": "AGENT_ADMIN_API_KEY"
+  },
+  "smtp": {
+    "host": "SMTP_HOST",
+    "port": "SMTP_PORT",
+    "secure": false,
+    "tls": {
+      "rejectUnauthorized": false
+    }
+  },
+  "emailSettings": {
+    "sender": "ADMIN_EMAIL",
+    "subject": "EMAIL_SUBJECT"
+  },
+  "publicSite": {
+    "url": "PUBLIC_SITE_URL"
+  },
+  "issuer": {
+    "name": "Unverified Person Issuer",
+    "offerComment": "Credential offer from Unverified Person Issuer",
+    "validityDays": -1,
+    "multiUse": true
+  },
+  "authentication": {
+    "jwksUri": "https://a2a-vc-authn-controller-test.pathfinder.gov.bc.ca/.well-known/openid-configuration/jwks",
+    "algorithms": ["RS256"]
+  }
+}


### PR DESCRIPTION
New configurations already deployed throughout the environments as it doesn't affect the current deployments.

I will need to verify in DEV when deployed that the ne issuer-kit code works when authenticating directly with vc-authn rather than using Keycloak, but other than that it should all be good.