### PR TITLE
Update issuer-web deployment configurations

### DIFF
--- a/openshift/templates/issuer-web/config/esr1/dev/config.json
+++ b/openshift/templates/issuer-web/config/esr1/dev/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Essential Services - Organization"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/esr1/help.html
+++ b/openshift/templates/issuer-web/config/esr1/help.html
@@ -1,0 +1,15 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <h3><strong>Custom Help</strong></h3>
+  <p class="paragraph">
+    Add your help content in this page.
+  </p>
+</div> -->

--- a/openshift/templates/issuer-web/config/esr1/prod/config.json
+++ b/openshift/templates/issuer-web/config/esr1/prod/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Essential Services - Organization"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/esr1/test/config.json
+++ b/openshift/templates/issuer-web/config/esr1/test/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Essential Services - Organization"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/esr2/dev/config.json
+++ b/openshift/templates/issuer-web/config/esr2/dev/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Essential Services - Access"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/esr2/help.html
+++ b/openshift/templates/issuer-web/config/esr2/help.html
@@ -1,0 +1,15 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <h3><strong>Custom Help</strong></h3>
+  <p class="paragraph">
+    Add your help content in this page.
+  </p>
+</div> -->

--- a/openshift/templates/issuer-web/config/esr2/prod/config.json
+++ b/openshift/templates/issuer-web/config/esr2/prod/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Essential Services - Access"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/esr2/test/config.json
+++ b/openshift/templates/issuer-web/config/esr2/test/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Essential Services - Access"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/healthbc/dev/config.json
+++ b/openshift/templates/issuer-web/config/healthbc/dev/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Health Gateway"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/healthbc/help.html
+++ b/openshift/templates/issuer-web/config/healthbc/help.html
@@ -1,0 +1,15 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <h3><strong>Custom Help</strong></h3>
+  <p class="paragraph">
+    Add your help content in this page.
+  </p>
+</div> -->

--- a/openshift/templates/issuer-web/config/healthbc/prod/config.json
+++ b/openshift/templates/issuer-web/config/healthbc/prod/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Health Gateway"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/healthbc/test/config.json
+++ b/openshift/templates/issuer-web/config/healthbc/test/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Health Gateway"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/inoculation/dev/config.json
+++ b/openshift/templates/issuer-web/config/inoculation/dev/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Vancouver Island Health Authority"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/inoculation/help.html
+++ b/openshift/templates/issuer-web/config/inoculation/help.html
@@ -1,0 +1,15 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <h3><strong>Custom Help</strong></h3>
+  <p class="paragraph">
+    Add your help content in this page.
+  </p>
+</div> -->

--- a/openshift/templates/issuer-web/config/inoculation/prod/config.json
+++ b/openshift/templates/issuer-web/config/inoculation/prod/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Vancouver Island Health Authority"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/inoculation/test/config.json
+++ b/openshift/templates/issuer-web/config/inoculation/test/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Vancouver Island Health Authority"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/medlab/dev/config.json
+++ b/openshift/templates/issuer-web/config/medlab/dev/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Med Lab"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/medlab/help.html
+++ b/openshift/templates/issuer-web/config/medlab/help.html
@@ -1,0 +1,15 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <h3><strong>Custom Help</strong></h3>
+  <p class="paragraph">
+    Add your help content in this page.
+  </p>
+</div> -->

--- a/openshift/templates/issuer-web/config/medlab/prod/config.json
+++ b/openshift/templates/issuer-web/config/medlab/prod/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Med Lab"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/medlab/test/config.json
+++ b/openshift/templates/issuer-web/config/medlab/test/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Med Lab"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": true,

--- a/openshift/templates/issuer-web/config/openvp/dev/config.json
+++ b/openshift/templates/issuer-web/config/openvp/dev/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Unverified Person Issuer"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": false,

--- a/openshift/templates/issuer-web/config/openvp/help.html
+++ b/openshift/templates/issuer-web/config/openvp/help.html
@@ -1,0 +1,15 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <h3><strong>Custom Help</strong></h3>
+  <p class="paragraph">
+    Add your help content in this page.
+  </p>
+</div> -->

--- a/openshift/templates/issuer-web/config/openvp/prod/config.json
+++ b/openshift/templates/issuer-web/config/openvp/prod/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Unverified Person Issuer"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": false,

--- a/openshift/templates/issuer-web/config/openvp/test/config.json
+++ b/openshift/templates/issuer-web/config/openvp/test/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Unverified Person Issuer"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": false,

--- a/openshift/templates/issuer-web/config/openvp_rev/dev/config.json
+++ b/openshift/templates/issuer-web/config/openvp_rev/dev/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Unverified Person Issuer (Revocable)"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": false,

--- a/openshift/templates/issuer-web/config/openvp_rev/help.html
+++ b/openshift/templates/issuer-web/config/openvp_rev/help.html
@@ -1,0 +1,15 @@
+<!-- <style type="text/css">
+  .content {
+    padding: 25px;
+  }
+  .paragraph {
+    text-align: justify;
+  }
+</style>
+
+<div class="content">
+  <h3><strong>Custom Help</strong></h3>
+  <p class="paragraph">
+    Add your help content in this page.
+  </p>
+</div> -->

--- a/openshift/templates/issuer-web/config/openvp_rev/prod/config.json
+++ b/openshift/templates/issuer-web/config/openvp_rev/prod/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Unverified Person Issuer (Revocable)"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": false,

--- a/openshift/templates/issuer-web/config/openvp_rev/test/config.json
+++ b/openshift/templates/issuer-web/config/openvp_rev/test/config.json
@@ -3,6 +3,10 @@
   "issuer": {
     "name": "Unverified Person Issuer (Revocable)"
   },
+  "help": {
+    "enabled": false,
+    "displayOnFirstVisit": false
+  },
   "inviteRequired": false,
   "authentication": {
     "enabled": false,

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr1.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr1.param
@@ -21,6 +21,7 @@ APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
 APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+APP_HELP_FILE_NAME=help.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr1.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr1.prod.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr1.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr1.test.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr2.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr2.param
@@ -21,6 +21,7 @@ APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
 APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+APP_HELP_FILE_NAME=help.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr2.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr2.prod.param
@@ -22,7 +22,6 @@
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
 # APP_HELP_FILE_NAME=help.html
-# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr2.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr2.prod.param
@@ -21,6 +21,8 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.esr2.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.esr2.test.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.healthbc.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.healthbc.param
@@ -21,6 +21,7 @@ APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
 APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+APP_HELP_FILE_NAME=help.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.healthbc.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.healthbc.prod.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.healthbc.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.healthbc.test.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.inoculation.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.inoculation.param
@@ -21,6 +21,7 @@ APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
 APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+APP_HELP_FILE_NAME=help.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.inoculation.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.inoculation.prod.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.inoculation.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.inoculation.test.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.json
+++ b/openshift/templates/issuer-web/issuer-web-deploy.json
@@ -136,6 +136,18 @@
                 }
               },
               {
+                "name": "${NAME}${SUFFIX}-app-help-volume",
+                "configMap": {
+                  "name": "${APP_CONFIG_MAP_NAME}${SUFFIX}",
+                  "items": [
+                    {
+                      "key": "${APP_HELP_FILE_NAME}",
+                      "path": "${APP_HELP_FILE_NAME}"
+                    }
+                  ]
+                }
+              },
+              {
                 "name": "${NAME}${SUFFIX}-app-vuetify-volume",
                 "configMap": {
                   "name": "${APP_CONFIG_MAP_NAME}${SUFFIX}",
@@ -231,6 +243,11 @@
                     "name": "${NAME}${SUFFIX}-app-unauthorized-volume",
                     "mountPath": "${APP_ARTIFACT_MOUNT_PATH}${APP_UNAUTHORIZED_FILE_NAME}",
                     "subPath": "${APP_UNAUTHORIZED_FILE_NAME}"
+                  },
+                  {
+                    "name": "${NAME}${SUFFIX}-app-help-volume",
+                    "mountPath": "${APP_ARTIFACT_MOUNT_PATH}${APP_HELP_FILE_NAME}",
+                    "subPath": "${APP_HELP_FILE_NAME}"
                   }
                 ],
                 "livenessProbe": {
@@ -520,6 +537,13 @@
       "description": "The name of the application unauthorized file.",
       "required": true,
       "value": "unauthorized.html"
+    },
+    {
+      "name": "APP_HELP_FILE_NAME",
+      "displayName": "Application Help File Name",
+      "description": "The name of the application help file.",
+      "required": true,
+      "value": "help.html"
     },
     {
       "name": "WEB_HOST_NAME",

--- a/openshift/templates/issuer-web/issuer-web-deploy.medlab.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.medlab.param
@@ -21,6 +21,7 @@ APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
 APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+APP_HELP_FILE_NAME=help.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.medlab.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.medlab.prod.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.medlab.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.medlab.test.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp.param
@@ -21,6 +21,7 @@ APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
 APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+APP_HELP_FILE_NAME=help.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp.prod.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp.test.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp_rev.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp_rev.param
@@ -21,6 +21,7 @@ APP_CUSTOM_SCRIPTS_FILE_NAME=custom-scripts.js
 APP_LOGO_FILE_NAME=logo.svg
 APP_TERMS_FILE_NAME=terms-and-conditions.html
 APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+APP_HELP_FILE_NAME=help.html
 APP_VUETIFY_FILE_NAME=vuetify.json
 WEB_HOST_NAME=
 WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp_rev.prod.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp_rev.prod.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080

--- a/openshift/templates/issuer-web/issuer-web-deploy.openvp_rev.test.param
+++ b/openshift/templates/issuer-web/issuer-web-deploy.openvp_rev.test.param
@@ -21,6 +21,7 @@
 # APP_LOGO_FILE_NAME=logo.svg
 # APP_TERMS_FILE_NAME=terms-and-conditions.html
 # APP_UNAUTHORIZED_FILE_NAME=unauthorized.html
+# APP_HELP_FILE_NAME=help.html
 # APP_VUETIFY_FILE_NAME=vuetify.json
 # WEB_HOST_NAME=
 # WEB_HOST_PORT=8080


### PR DESCRIPTION
Resolves #89 

Deployments have been updated in all environments.

----

@swcurran if you want to add the help dialog for an issuer (after this PR i merged):
- update the `help.html` file for the profile the same way you have already done for the terms and conditions, adding your HTML content and styling.
- update `config.json` for that issuer, for each environment (`dev/test/prod`) and set help to `enabled: true`. This will turn the feature on and display a help icon in the navigation bar. If you also want the help dialog to automatically be displayed the first time a new user hits the credential data page for that website also set `displayOnFirstVisit: true`.